### PR TITLE
Fix half-pixel offsets when converting between cube maps and equirect

### DIFF
--- a/equilib/equi2cube/numpy.py
+++ b/equilib/equi2cube/numpy.py
@@ -100,8 +100,6 @@ def convert_grid(
         # but it was faster separately
         ui = (theta - np.pi) * w_equi / (2 * np.pi)
         uj = (np.pi / 2 - phi) * h_equi / np.pi  # NOTE: fixed here
-        ui += 0.5
-        uj += 0.5
         ui %= w_equi
         uj %= h_equi
     elif method == "faster":
@@ -112,8 +110,6 @@ def convert_grid(
         # out of range, it will not work with `faster`
         ui = (theta - np.pi) * w_equi / (2 * np.pi)
         uj = (np.pi / 2 - phi) * h_equi / np.pi  # NOTE: fixed here
-        ui += 0.5
-        uj += 0.5
         ui = np.where(ui < 0, ui + w_equi, ui)
         ui = np.where(ui >= w_equi, ui - w_equi, ui)
         uj = np.where(uj < 0, uj + h_equi, uj)
@@ -123,7 +119,7 @@ def convert_grid(
 
     # stack the pixel maps into a grid
     grid = np.stack((uj, ui), axis=-3)
-
+    grid = grid - 0.5 # offset pixel center
     return grid
 
 

--- a/equilib/equi2cube/torch.py
+++ b/equilib/equi2cube/torch.py
@@ -94,15 +94,11 @@ def convert_grid(
     if method == "robust":
         ui = (theta - pi) * w_equi / (2 * pi)
         uj = (pi / 2 - phi) * h_equi / pi  # FIXME: fixed here
-        ui += 0.5
-        uj += 0.5
         ui %= w_equi
         uj %= h_equi
     elif method == "faster":
         ui = (theta - pi) * w_equi / (2 * pi)
         uj = (pi / 2 - phi) * h_equi / pi  # FIXME: fixed here
-        ui += 0.5
-        uj += 0.5
         ui = torch.where(ui < 0, ui + w_equi, ui)
         ui = torch.where(ui >= w_equi, ui - w_equi, ui)
         uj = torch.where(uj < 0, uj + h_equi, uj)
@@ -112,7 +108,7 @@ def convert_grid(
 
     # stack the pixel maps into a grid
     grid = torch.stack((uj, ui), dim=-3)
-
+    grid = grid - 0.5 # offset pixel center
     return grid
 
 

--- a/equilib/numpy_utils/grid.py
+++ b/equilib/numpy_utils/grid.py
@@ -104,7 +104,8 @@ def create_xyz_grid(
 ) -> np.ndarray:
     """xyz coordinates of the faces of the cube"""
     out = np.zeros((w_face, w_face * 6, 3), dtype=dtype)
-    rng = np.linspace(-0.5, 0.5, num=w_face, dtype=dtype)
+    pixel_half_width = 0.5 / w_face
+    rng = np.linspace(-0.5 + pixel_half_width, 0.5 - pixel_half_width, num=w_face, dtype=dtype)
 
     # Front face (x = 0.5)
     out[:, 0 * w_face : 1 * w_face, [1, 2]] = np.stack(


### PR DESCRIPTION
There were multiple sources of half-pixel offsets, which caused small inaccuracies when converting between cube maps and equirectangular images. These are now fixed.

Fixes issue #8

This change is sponsored by [Higharc](https://higharc.com)