### PR TITLE
Clamp bilinear samples to cube map face

### DIFF
--- a/equilib/cube2equi/numpy.py
+++ b/equilib/cube2equi/numpy.py
@@ -214,7 +214,7 @@ def create_equi_grid(
     grid = np.stack((coor_y, coor_x), axis=0)
     grid = np.concatenate([grid[np.newaxis, ...]] * batch)
     grid = grid - 0.5  # Offset pixel center
-    return grid
+    return (grid, tp)
 
 
 def run(
@@ -269,7 +269,7 @@ def run(
     out = np.empty((bs, c, height, width), dtype=dtype)
 
     # create sampling grid
-    grid = create_equi_grid(
+    (grid, tp) = create_equi_grid(
         h_out=height, w_out=width, w_face=w_face, batch=bs, dtype=dtype
     )
 
@@ -279,7 +279,7 @@ def run(
             img=horizon, grid=grid, out=out, mode=mode
         )
     else:
-        out = numpy_grid_sample(img=horizon, grid=grid, out=out, mode=mode)
+        out = numpy_grid_sample(img=horizon, grid=grid, out=out, mode=mode, cube_face_id=tp)
 
     out = (
         out.astype(horizon_dtype)

--- a/equilib/grid_sample/numpy/bilinear.py
+++ b/equilib/grid_sample/numpy/bilinear.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from functools import partial
 import numpy as np
 
 __all__ = ["bilinear"]
@@ -14,8 +15,13 @@ def interp2d(q00, q10, q01, q11, dy, dx):
     f1 = interp(q10, q11, dx, 1)
     return interp(f0, f1, dy, 1)
 
+def clamp_zero(a):
+    return max(a, 0)
 
-def bilinear(img: np.ndarray, grid: np.ndarray, out: np.ndarray) -> np.ndarray:
+def clamp_upper(h, a):
+    return min(a, h)
+
+def bilinear(img: np.ndarray, grid: np.ndarray, out: np.ndarray, cube_face_id: np.ndarray = np.array(None)) -> np.ndarray:
     """Bilinear Interpolation
 
     NOTE: asserts are removed
@@ -27,10 +33,30 @@ def bilinear(img: np.ndarray, grid: np.ndarray, out: np.ndarray) -> np.ndarray:
     max_grid = min_grid + 1
     d_grid = grid - min_grid
 
-    min_grid[:, 0, :, :] %= h
-    min_grid[:, 1, :, :] %= w
-    max_grid[:, 0, :, :] %= h
-    max_grid[:, 1, :, :] %= w
+    if (len(cube_face_id.shape) > 0):
+        bb, _, grid_h, grid_w = grid.shape
+        cube_face_min_grid = min_grid // h
+        cube_face_max_grid = max_grid // h
+
+        clamp_y_lower = np.vectorize(clamp_zero)
+        clamp_y_upper = np.vectorize(partial(clamp_upper, h - 1))
+
+        min_grid[:, 0, :, :] = clamp_y_lower(min_grid[:, 0, :, :])
+        max_grid[:, 0, :, :] = clamp_y_upper(max_grid[:, 0, :, :])
+
+        for i in range(bb):
+            for y in range(grid_h):
+                for x in range(grid_w):
+                    if cube_face_max_grid[i, 1, y, x] != cube_face_min_grid[i, 1, y, x]:
+                        if cube_face_max_grid[i, 1, y, x] != cube_face_id[y, x]:
+                            max_grid[i, 1, y, x] -= 1
+                        else:
+                            min_grid[i, 1, y, x] += 1
+    else:
+        min_grid[:, 0, :, :] %= h
+        min_grid[:, 1, :, :] %= w
+        max_grid[:, 0, :, :] %= h
+        max_grid[:, 1, :, :] %= w
 
     # FIXME: any way to do efficient batch?
     for i in range(b):

--- a/equilib/grid_sample/numpy/grid_sample.py
+++ b/equilib/grid_sample/numpy/grid_sample.py
@@ -8,7 +8,7 @@ from .nearest import nearest
 
 
 def grid_sample(
-    img: np.ndarray, grid: np.ndarray, out: np.ndarray, mode: str = "bilinear"
+    img: np.ndarray, grid: np.ndarray, out: np.ndarray, mode: str = "bilinear", cube_face_id: np.ndarray = np.array(None)
 ) -> np.ndarray:
     """Numpy grid sampling algorithm
 
@@ -31,7 +31,7 @@ def grid_sample(
     if mode == "nearest":
         out = nearest(img, grid, out)
     elif mode == "bilinear":
-        out = bilinear(img, grid, out)
+        out = bilinear(img, grid, out, cube_face_id)
     elif mode == "bicubic":
         out = bicubic(img, grid, out)
     else:


### PR DESCRIPTION
Sample locations can overflow to neighboring cube map faces, which will lead to slight artifacts if not addressed.

The best solution would be to mutate the coordinates to sample the correct neighboring faces in case of overflow, but clamping will at least mitigate the problem and is much simpler to implement.

This change is sponsored by [Higharc](https://www.higharc.com/)