### PR TITLE
Add a functional argument to decide whether skip clip before final result.

### DIFF
--- a/equilib/equi2pers/numpy.py
+++ b/equilib/equi2pers/numpy.py
@@ -131,6 +131,7 @@ def run(
     z_down: bool,
     mode: str,
     override_func: Optional[Callable[[], Any]] = None,
+    clip_output: bool = True
 ) -> np.ndarray:
     """Run Equi2Pers
 
@@ -224,7 +225,7 @@ def run(
 
     out = (
         out.astype(equi_dtype)
-        if equi_dtype == np.dtype(np.uint8)
+        if equi_dtype == np.dtype(np.uint8) or not clip_output
         else np.clip(out, 0.0, 1.0)
     )
 

--- a/equilib/equi2pers/numpy.py
+++ b/equilib/equi2pers/numpy.py
@@ -131,7 +131,7 @@ def run(
     z_down: bool,
     mode: str,
     override_func: Optional[Callable[[], Any]] = None,
-    clip_output: bool = True
+    clip_output: bool = True,
 ) -> np.ndarray:
     """Run Equi2Pers
 

--- a/equilib/equi2pers/torch.py
+++ b/equilib/equi2pers/torch.py
@@ -117,6 +117,7 @@ def run(
     z_down: bool,
     mode: str,
     backend: str = "native",
+    clip_output: bool = True,
 ) -> torch.Tensor:
     """Run Equi2Pers
 
@@ -242,7 +243,7 @@ def run(
 
     out = (
         out.type(equi_dtype)
-        if equi_dtype == torch.uint8
+        if equi_dtype == torch.uint8 or not clip_output
         else torch.clip(out, 0.0, 1.0)
     )
 


### PR DESCRIPTION
Hi, I want to use the equilib without clip process before the final result. Here I include an function argument `clip_output: bool` to decide whether do clip. I tested it on HDR image successfully on Equi2Pers. It's compatible to the previous equilib. To disable clip, just include  `clip_output = False` when doing Equi2Pers. Here is the test case of crop a perspective view from the .exr file which refer to a equir HDR image. In this pull request, I just modify the Equi2Pers part, but you can disable clip to Equi2other format the same as this. 

```
img= cv2.imread(PATH_TO_EXR_FILE,  cv2.IMREAD_UNCHANGED)
from equilib import Equi2Pers
v_rad, u_rad = (0, 0)
fov = 120
equi2pers = Equi2Pers(height=960, width=960, fov_x=fov, mode="bilinear")
pers_image = equi2pers(img, rots={"roll": 0, "pitch": v_rad, "yaw": u_rad}, clip_output=False)

```