### PR TITLE
No clip to 0-1

### DIFF
--- a/equilib/cube2equi/numpy.py
+++ b/equilib/cube2equi/numpy.py
@@ -323,7 +323,7 @@ def run(
     out = (
         out.astype(horizon_dtype)
         if horizon_dtype == np.dtype(np.uint8)
-        else np.clip(out, 0.0, 1.0)
+        else np.clip(out, np.nanmin(out), np.nanmax(out))
     )
 
     return out

--- a/equilib/equi2cube/numpy.py
+++ b/equilib/equi2cube/numpy.py
@@ -206,7 +206,7 @@ def run(
     out = (
         out.astype(equi_dtype)
         if equi_dtype == np.dtype(np.uint8)
-        else np.clip(out, 0.0, 1.0)
+        else np.clip(out, np.nanmin(out), np.nanmax(out))
     )
 
     # reformat the output

--- a/equilib/equi2equi/numpy.py
+++ b/equilib/equi2equi/numpy.py
@@ -172,7 +172,7 @@ def run(
     out = (
         out.astype(src_dtype)
         if src_dtype == np.dtype(np.uint8)
-        else np.clip(out, 0.0, 1.0)
+        else np.clip(out, np.nanmin(out), np.nanmax(out))
     )
 
     return out

--- a/equilib/equi2pers/numpy.py
+++ b/equilib/equi2pers/numpy.py
@@ -226,7 +226,7 @@ def run(
     out = (
         out.astype(equi_dtype)
         if equi_dtype == np.dtype(np.uint8) or not clip_output
-        else np.clip(out, 0.0, 1.0)
+        else np.clip(out, np.nanmin(out), np.nanmax(out))
     )
 
     return out


### PR DESCRIPTION
Generally images may not belong to the range [0, 1] for several reasons:
* HDR images (captured real image or rendered synthetic image)
* Difference map of two images
* Signed values for differentiable rendering
* Other non-RGB radiance quantities can be considered as images including normal vectors, wave optics-based images, etc.